### PR TITLE
Update searchpage.js to fix query param issue

### DIFF
--- a/public/javascripts/searchpage.js
+++ b/public/javascripts/searchpage.js
@@ -318,7 +318,13 @@ function replaceAllRecordsHref() {
         currentHref += "pageNo=1";
     }
 
-    currentHref += "&stepSize=-1"
+    if (currentHref.includes("stepSize=")) {
+
+        currentHref = currentHref.replace(/stepSize=\d/, "stepSize=-1");
+    } else {
+
+        currentHref += "&stepSize=-1";
+    }
 
     return currentHref;
 }


### PR DESCRIPTION
This should fix the additional query param which is breaking the website if the "See All Records" link is pressed twice.